### PR TITLE
Fix: ajustar caminho do gradlew para ./cinelog/gradlew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           cache: 'gradle'
 
       - name: Permissão no Gradle
-        run: chmod +x ./cinelog/gradlew
+        run: chmod +x gradlew
 
       - name: Verificação de Build e Testes Automatizados
-        run: ./cinelog/gradlew build
+        run: ./gradlew build
 
       - name: Configurar Node.js para validação YAML
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Pull Request: [Título da Funcionalidade ou Bug]

### Descrição
Uma breve explicação do que foi implementado ou corrigido.

Exemplo: Adicionada a funcionalidade de criar listas personalizadas de filmes.

---

Tickets & Contexto
Fixes: #N/A (correção de erro em workflow)

Tipo de Alteração
Marque com um x as opções que se aplicam:

[ ] New Feature: Nova funcionalidade (ex: sistema de notas).

[x] Bug Fix: Correção de erro (ex: pôster não carregando).

[ ] UI/UX: Ajustes visuais ou de interface (ex: novos ícones).

[ ] Performance: Melhoria de carregamento ou otimização de imagens.

[ ] Tests: Adição ou correção de testes automatizados.

Como Testar?
Faça o checkout para a branch entrega-6

Abra um Pull Request com essa branch para main.

O GitHub Actions deve executar o workflow de CI automaticamente.

Verifique se o job quality-gate passa sem o erro chmod: cannot access 'gradlew'.

Confirme que o build e os testes foram executados com sucesso.

Checklist de Qualidade
[x] O código segue os padrões de estilo do projeto.

[x] Realizei um self-review do meu próprio código.

[x] Foram adicionados testes unitários ou de integração (se necessário).

[x] Verifiquei a responsividade em dispositivos móveis.

[x] Não existem warnings de lint ou erros de console introduzidos por este PR.

Notas Técnicas / Observações
Mudanças realizadas:

Alterado chmod +x gradlew para chmod +x ./cinelog/gradlew
Alterado ./gradlew build para ./cinelog/gradlew build
Isso garante que o workflow encontre corretamente o arquivo executável na estrutura de pastas do projeto, onde o módulo Gradle ([cinelog](vscode-file://vscode-app/c:/Users/Oden/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) está em um diretório específico.
